### PR TITLE
Fetch not being called because model was being created without an id

### DIFF
--- a/src/sports/teamInstance.js
+++ b/src/sports/teamInstance.js
@@ -17,9 +17,9 @@ module.exports = function(ngin) {
 
   function scopeUrl(options, inst) {
     options = _.extend(_.clone(options || {}), inst)
-    if (!options.subseason_id || !options.team_id)
+    if (!options.subseason_id || !options.id)
       throw new Error('subseason_id and team_id required to make team instance api calls')
-    return ngin.Subseason.urlRoot() + '/' + options.subseason_id + '/teams/' + options.team_id
+    return ngin.Subseason.urlRoot() + '/' + options.subseason_id + '/teams/' + options.id
   }
 
   /**


### PR DESCRIPTION
We were passing subseason_id and team_id which wasn't calling fetch because the model didn't have an id. I just changed team_id to be straight up id for this case.
