### PR TITLE
Lock request module

### DIFF
--- a/src/sports/teamInstance.js
+++ b/src/sports/teamInstance.js
@@ -17,9 +17,9 @@ module.exports = function(ngin) {
 
   function scopeUrl(options, inst) {
     options = _.extend(_.clone(options || {}), inst)
-    if (!options.subseason_id || !options.id)
+    if (!options.subseason_id || !options.team_id)
       throw new Error('subseason_id and team_id required to make team instance api calls')
-    return ngin.Subseason.urlRoot() + '/' + options.subseason_id + '/teams/' + options.id
+    return ngin.Subseason.urlRoot() + '/' + options.subseason_id + '/teams/' + options.team_id
   }
 
   /**


### PR DESCRIPTION
The new version of request 2.18.0 uses verson 0.3.0 of tunnel-agent which is breaking things so I'm locking this to version 2.16.6 for now.
