### PR TITLE
if page is set to 0, don't add pagination data to list

### DIFF
--- a/src/modelbase.js
+++ b/src/modelbase.js
@@ -163,7 +163,7 @@ module.exports = function(ngin) {
 
           // check for a single page request
           if (options.page || !pagination || (pagination && pagination.total_pages === 1)) {
-            list._pagination = pagination
+            if (options.page !== 0) list._pagination = pagination
             return callback(err, list, resp)
           }
 


### PR DESCRIPTION
When page is set to 0, lists are still getting pagination data which causes fetches after to be limited to 100 list items
